### PR TITLE
Update documentation

### DIFF
--- a/docs/backend/openapi.yaml
+++ b/docs/backend/openapi.yaml
@@ -890,7 +890,10 @@ paths:
   /results:
     get:
       summary: Allows getting results of the simulation.
-      description: If `estimator_name` is provided, the response will include results only for that specific estimator, otherwise it will return all estimators for the given job.
+      description: This endpoint retrieves the results of a simulation. If the `estimator_name` parameter is provided,
+        the response will include results only for the specified estimator. If no `estimator_name` is provided,
+        the response will include results for all estimators associated with the job. Additionally, you can
+        specify pages using the `page_number` or `page_numbers` parameter to limit the response to specific pages.
       parameters:
         - in: query
           name: job_id
@@ -904,6 +907,18 @@ paths:
           description: Name of a specific estimator to retrieve results for
           schema:
             type: string
+        - in: query
+          name: page_number
+          required: false
+          description: Retrieve a specific page of results for the specified estimator.
+          schema:
+            type: integer
+        - in: query
+          name: page_numbers
+          required: false
+          description: Retrieve a specific pages of results for the specified estimator. For example, `"1-3,5"` would retrieve pages 1 through 3 and page 5.
+          schema:
+            type: integer
       responses:
         '200':
           description: Includes results of the simulation
@@ -925,6 +940,20 @@ paths:
                         type: string
                       estimator:
                           $ref: '#/components/schemas/Estimator'
+                  - type: object
+                    properties:
+                      message:
+                        type: string
+                      pages:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Page'
+                  - type: object
+                    properties:
+                      message:
+                        type: string
+                      page:
+                          $ref: '#/components/schemas/Page'                  
         '400':
           description: Bad Request - Missing parameters
           content:
@@ -959,17 +988,17 @@ paths:
 # Estimator Routes
   /estimators:
     get:
-      summary: Allows getting names of the estimators for the specific simulation.
+      summary: Allows getting metadata of estimators for a specific simulation.
       parameters:
         - in: query
           name: job_id
           required: true
-          description: ID of the job to retrieve results for
+          description: ID of the job to estimators metadata results for
           schema:
             type: string
       responses:
         '200':
-          description: Includes estimator names
+          description: Includes estimator metadata
           content:
             application/json:
               schema:
@@ -977,10 +1006,24 @@ paths:
                 properties:
                   message:
                     type: string
-                  estimator_names:
+                  estimators_metadata:
                     type: array
                     items:
-                      type: string
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        pages_metadata:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              page_number:
+                                type: integer
+                              page_name:
+                                type: string
+                              page_dimension:
+                                type: integer
         '400':
           description: Bad Request - Missing parameters
           content:
@@ -1334,6 +1377,9 @@ components:
         task_state:
           type: string
           enum: [PENDING, RUNNING, COMPLETED, FAILED]
+    Page: 
+      type: object
+      description: Page object
     Estimator:
       type: object
       description: Estimator object includes estimator's name, associated metadata, and list of pages.
@@ -1348,8 +1394,7 @@ components:
           type: array
           description: List of pages
           items:
-            type: object
-            description: Page object
+            $ref: '#/components/schemas/Page'
     UpdateJobs:
       type: object
       required:

--- a/docs/backend/openapi.yaml
+++ b/docs/backend/openapi.yaml
@@ -993,12 +993,12 @@ paths:
         - in: query
           name: job_id
           required: true
-          description: ID of the job to estimators metadata results for
+          description: ID of the job to retrieve estimators metadata for
           schema:
             type: string
       responses:
         '200':
-          description: Includes estimator metadata
+          description: Includes estimators metadata
           content:
             application/json:
               schema:

--- a/docs/backend/persistency.md
+++ b/docs/backend/persistency.md
@@ -69,14 +69,17 @@ classDiagram
     id: int
     simulation_id: int
     name: str
+    file_name: str
     compressed_data: bytes
     data
   }
 
   class PageModel {
     id: int
+    page_name: str
     estimator_id: int
     page_number: int
+    page_dimension: int
     compressed_data: bytes
     data
   }


### PR DESCRIPTION
This pull request includes significant updates to the OpenAPI documentation for the backend, specifically focusing on enhancing the simulation results and estimator metadata retrieval endpoints. The changes include adding new query parameters for pagination, updating response descriptions, and introducing new schemas for better structuring the data.

Enhancements to simulation results retrieval:

* [`docs/backend/openapi.yaml`](diffhunk://#diff-f6ed14a9c06568904ff02c50af9e84d6fe347ca5fbdc81d609d7aa1e8f89fe15L893-R896): Updated the description for the `/results` endpoint to include details about the new `page_number` and `page_numbers` query parameters, which allow for paginated retrieval of results.
* [`docs/backend/openapi.yaml`](diffhunk://#diff-f6ed14a9c06568904ff02c50af9e84d6fe347ca5fbdc81d609d7aa1e8f89fe15R910-R921): Added `page_number` and `page_numbers` as optional query parameters in the `/results` endpoint to support paginated results.
* [`docs/backend/openapi.yaml`](diffhunk://#diff-f6ed14a9c06568904ff02c50af9e84d6fe347ca5fbdc81d609d7aa1e8f89fe15R943-R956): Introduced new response objects to include pagination information in the `/results` endpoint.

Enhancements to estimator metadata retrieval:

* [`docs/backend/openapi.yaml`](diffhunk://#diff-f6ed14a9c06568904ff02c50af9e84d6fe347ca5fbdc81d609d7aa1e8f89fe15L962-R1026): Updated the summary and response description for the `/estimators` endpoint to reflect the retrieval of estimator metadata instead of just names.
* [`docs/backend/openapi.yaml`](diffhunk://#diff-f6ed14a9c06568904ff02c50af9e84d6fe347ca5fbdc81d609d7aa1e8f89fe15L962-R1026): Added detailed properties for the `estimators_metadata` response, including page metadata.

Schema updates:

* [`docs/backend/openapi.yaml`](diffhunk://#diff-f6ed14a9c06568904ff02c50af9e84d6fe347ca5fbdc81d609d7aa1e8f89fe15R1380-R1382): Added a new `Page` schema to represent page objects in the API responses.
* [`docs/backend/openapi.yaml`](diffhunk://#diff-f6ed14a9c06568904ff02c50af9e84d6fe347ca5fbdc81d609d7aa1e8f89fe15L1351-R1397): Updated the `Estimator` schema to reference the new `Page` schema for better data structuring.

Additional changes:

* [`docs/backend/persistency.md`](diffhunk://#diff-6bf46c75b39ff3c23cec0db458b3d7a9df3e6f57f55d1aea0db8907a157b8189R72-R82): Updated the class diagram to include new fields `file_name`, `page_name`, and `page_dimension` in the `PageModel` class.